### PR TITLE
MNT: add codeowners file to template.

### DIFF
--- a/{{ cookiecutter.folder_name }}/.github/CODEOWNERS
+++ b/{{ cookiecutter.folder_name }}/.github/CODEOWNERS
@@ -1,0 +1,14 @@
+# default group
+* @pcdshub/python-reviewers @pcdshub/epics-reviewers
+
+# language-specific group(s)
+## PYTHON files
+*.py @pcdshub/python-reviewers
+*.pyi @pcdshub/python-reviewers
+*.pyc @pcdshub/python-reviewers
+*.pyw @pcdshub/python-reviewers
+*.pyx @pcdshub/python-reviewers
+*.pyd @pcdshub/python-reviewers
+
+# github folder holds administrative files
+.github/** @pcdshub/software-admin


### PR DESCRIPTION
## Description
Adds a CODEOWNERS file to the template portion of this repository

## Motivation and Context
We want these CODEOWNERS to exist automatically. 

Does anyone use this cookiecutter? 🤷 

## How Has This Been Tested?
N/A

## Where Has This Been Documented?
This PR